### PR TITLE
add is_admin to users table migration

### DIFF
--- a/app/Http/Controllers/PlayerController.php
+++ b/app/Http/Controllers/PlayerController.php
@@ -15,8 +15,9 @@ class PlayerController extends Controller
             foreach ($players as $player) {
                 if ($player['set_uuid'] == $request->query('set_uuid')) {
                     array_push($filterPlayers, $player);
-                };
+                }
             }
+
             return $filterPlayers;
         } else {
             return Player::with(['set', 'season', 'season.team'])->get();

--- a/database/migrations/2023_04_25_023606_add_is_admin_to_user_table.php
+++ b/database/migrations/2023_04_25_023606_add_is_admin_to_user_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->boolean('is_admin');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('is_admin');
+        });
+    }
+};


### PR DESCRIPTION
## What does this PR do?
adds the is_admin column to the users table
## Related PRs

## Testing Steps
- pull branch
- run migration
`php artisan migrate`
- see that is_admin column has been added to users table
## Checklist before merging
- [ ] If its a core feature, I have added through test.
- [ ] Do we need to implement analytics? 
- [ ] Will this be part of a product update? If yes, please write one phrase about this update
